### PR TITLE
긴급 repo 사용법 공지

### DIFF
--- a/src/main/kotlin/com/onetatwopi/jandi/client/GitClient.kt
+++ b/src/main/kotlin/com/onetatwopi/jandi/client/GitClient.kt
@@ -28,8 +28,8 @@ object GitClient {
     private val userToken: String? get() = inputToken
     private var inputId: String? = null
     private var inputToken: String? = null
-    val repos: ImmutableList<String>? get() = inputRepos
-    private var inputRepos: ImmutableList<String>? = null
+    val repos: ImmutableList<String> get() = inputRepos
+    private lateinit var inputRepos: ImmutableList<String>
     private val gson = Gson()
 
     private const val timeout = 2000
@@ -168,8 +168,13 @@ object GitClient {
         setRepos()
 
         try {
-            writeToUserFile(userInfo = UserInfo(userId = loginId!!, userToken = userToken))
             LoginIdChangeNotifier.notifyLoginIdChanged(inputId)
+        } catch (e : Exception) {
+            e.printStackTrace()
+        }
+
+        try {
+            writeToUserFile(userInfo = UserInfo(userId = loginId!!, userToken = userToken))
         } catch (e: Exception) {
             e.printStackTrace()
             throw cannotWriteFileException()

--- a/src/test/kotlin/GitClientTest.kt
+++ b/src/test/kotlin/GitClientTest.kt
@@ -14,10 +14,10 @@ class GitClientTest {
     @Test
     fun `외부 api 테스트`() {
         GitClient.login("")
-        println(GitClient.repoRequest(method = HTTPMethod.GET, repo = "kt-hhplus", category = Category.ISSUE, number = 1))
-        println(GitClient.repoRequest(method = HTTPMethod.POST, repo = "kt-hhplus", category = Category.ISSUE, body =
+        println(GitClient.repoRequest(method = HTTPMethod.GET, repo = GitClient.repos[1], category = Category.ISSUE, number = 1))
+        println(GitClient.repoRequest(method = HTTPMethod.POST, repo = GitClient.repos[0], category = Category.ISSUE, body =
         listOf(BasicNameValuePair("title", "find a bug"))))
-        println(GitClient.repoRequest(method = HTTPMethod.PATCH, repo = "kt-hhplus", category = Category.PULL, number = 7,
+        println(GitClient.repoRequest(method = HTTPMethod.PATCH, repo = GitClient.repos[0], category = Category.PULL, number = 7,
             body = listOf(BasicNameValuePair("title", "test pr"), BasicNameValuePair("base", "master"))
         ))
         // String으로 반환하기 때문에 여기서 Gson으로 파싱하여 사용할 것 권장, object Mapper 써도 되지만 Gson이 더 나을듯?...


### PR DESCRIPTION
테스트 코드 보시고 GitClient.repos로 접근하여 사용 바랍니다. 
왜냐하면 현재 등록된 깃계정과 다른 깃토큰으로 사용할 수 있기때문에 무조건 플러그인에 등록된 깃계정으로 사용할 것이므로 repo는 GitClient에 등록되어 있는 것을 사용하여야합니다. 